### PR TITLE
License VCOM under APL-SA

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,5 @@
+Copyright 2018 genesis92x
+
+This work (VcomAI or the like) uses the license Arma Public License Share Alike (APL-SA)
+
+https://www.bohemia.net/community/licenses/arma-public-license-share-alike


### PR DESCRIPTION
Figured that it is probably not a bad idea to get this work under the APL-SA license, which has four main components:

**Attribution** - You must attribute the material in the manner specified by the author or licensor (but not in any way that suggests that they endorse you or your use of the material).  
**Noncommercial** - You may not use this material for any commercial purposes.
**Arma Only** - You may not convert or adapt this material to be used in other games than Arma.  
**Share Alike** - If you adapt, or build upon this material, you may distribute the resulting material only under the same license.

https://www.bohemia.net/community/licenses/arma-public-license-share-alike