### PR TITLE
Ai skill options

### DIFF
--- a/Vcom/FSMS/fn_SQUADBEH.fsm
+++ b/Vcom/FSMS/fn_SQUADBEH.fsm
@@ -176,7 +176,8 @@ class FSM
                                          "private _ehList = [];" \n
                                          "" \n
                                          "_Group call VCM_fnc_ArtyManage;" \n
-                                         "if (VCM_SKILLCHANGE && {_Group getVariable [""VCM_Skilldisable"", false]}) then {_Group call VCM_AIDIFSET};" \n
+                                         "private _isskilldisabled = _Group getVariable ""VCM_Skilldisable"";" \n
+                                         "if (VCM_SKILLCHANGE && isnil ""_isskilldisabled"") then {_Group call VCM_AIDIFSET};" \n
                                          "" \n
                                          "" \n
                                          "{" \n

--- a/Vcom/Functions/VCM_CBASettings.sqf
+++ b/Vcom/Functions/VCM_CBASettings.sqf
@@ -10,7 +10,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     true, // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_ActivateAI = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -23,7 +23,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
 	false,// data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_Debug = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -36,7 +36,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [[[west,east,resistance],[west,east],[west],[east],[resistance],[resistance,west],[resistance,east]],[["West, East, Resistance"],["West, East"],["West"],["East"],["Resistance"],["Resistance, West"],["Resistance, East"]],0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_SIDEENABLED = _this;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -49,7 +49,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     false, // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_ARTYENABLE = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -62,7 +62,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [[[west,east,resistance],[west,east],[west],[east],[resistance],[resistance,west],[resistance,east]],[["West, East, Resistance"],["West, East"],["West"],["East"],["Resistance"],["Resistance, West"],["Resistance, East"]],0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_ARTYSIDES = _this;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -75,7 +75,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
 	true,// data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_StealVeh = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -88,7 +88,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
 	true,// data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_FullSpeed = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -101,7 +101,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
 	true,// data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_ADVANCEDMOVEMENT = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -114,7 +114,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
 	true,// data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_FRMCHANGE = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -127,7 +127,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
 	true,// data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_SKILLCHANGE = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -140,7 +140,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1000,100,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_AIDISTANCEVEHPATH = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -153,7 +153,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
 	true,// data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_RAGDOLL = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -166,7 +166,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,100,50,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_RAGDOLLCHC = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -180,7 +180,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,10000,800,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_HEARINGDISTANCE = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -193,7 +193,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,10000,1000,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_WARNDIST = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -206,7 +206,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,10000,30,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_WARNDELAY = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -219,7 +219,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,10000,300,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_STATICARMT = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -233,7 +233,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,100,75,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_MINECHANCE = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -246,7 +246,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,5000,300,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_ARTYDELAY = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -259,7 +259,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,5000,400,0], // data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_ARTYSPREAD = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -273,7 +273,7 @@ if !(CBAACT) exitwith {};
     "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [2,10,5,0], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
         VCM_AIMagLimit = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -288,7 +288,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     true, // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		VCM_FFEARTILLERY = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -301,7 +301,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     false, // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_Debug = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -314,7 +314,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     "", // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_FO = [];
 		{RydFFE_FO pushBack (missionNamespace getVariable _x)} forEach (_value splitstring ", ");
@@ -328,7 +328,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     "i_spotter_f, o_spotter_f, b_spotter_f, o_recon_jtac_f, b_recon_jtac_f, i_sniper_f, o_sniper_f, b_sniper_f, i_soldier_m_f, o_soldier_m_f, b_g_soldier_m_f, b_soldier_m_f, o_recon_m_f, b_recon_m_f, o_soldieru_m_f, i_uav_01_f, i_uav_02_cas_f, i_uav_02_f, o_uav_01_f, o_uav_02_cas_f, o_uav_02_f, b_uav_01_f, b_uav_02_cas_f, b_uav_02_f", // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_FOClass = _value splitstring ", ";
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -341,7 +341,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     false, // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_OnePhase = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -354,7 +354,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     false, // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_2PhWithoutFO = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -367,7 +367,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [1, 4, 2, 0], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_Acc = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -380,7 +380,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [20, 300, 100, 0], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_Safe = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -393,7 +393,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     true, // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_Monogamy = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -406,7 +406,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [1, 12, 6, 0], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_Amount = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -419,7 +419,7 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     false, // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_ShellView = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
@@ -432,9 +432,130 @@ if !(CBAACT) exitwith {};
     "Fire For Effect", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0.5,3,1,1], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {  
+    {
         params ["_value"];
 		RydFFE_FoAccGain = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+//AI SKILL SETTINGS
+//Aiming Accuracy
+[
+    "VCM_AISKILL_AIMINGACCURACY_W", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Accuracy (West)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.25,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGACCURACY_W = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+[
+    "VCM_AISKILL_AIMINGACCURACY_E", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Accuracy (East)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.25,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGACCURACY_E = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+[
+    "VCM_AISKILL_AIMINGACCURACY_R", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Accuracy (Independent)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.25,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGACCURACY_R = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+//Aiming Shake
+[
+    "VCM_AISKILL_AIMINGSHAKE_W", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Shake (West)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.15,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGSHAKE_W = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+[
+    "VCM_AISKILL_AIMINGSHAKE_E", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Shake (East)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.15,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGSHAKE_E = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+[
+    "VCM_AISKILL_AIMINGSHAKE_R", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Shake (Independent)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.15,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGSHAKE_R = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+//Aiming Speed
+[
+    "VCM_AISKILL_AIMINGSPEED_W", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Speed (West)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.35,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGSPEED_W = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+[
+    "VCM_AISKILL_AIMINGSPEED_E", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Speed (East)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.35,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGSPEED_E = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+[
+    "VCM_AISKILL_AIMINGSPEED_R", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "AI Aiming Speed (Independent)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0,1,0.35,2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_AISKILL_AIMINGSPEED_R = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
 ] call CBA_Settings_fnc_init;
 

--- a/Vcom/Functions/VCM_CBASettings.sqf
+++ b/Vcom/Functions/VCM_CBASettings.sqf
@@ -432,11 +432,24 @@ if !(CBAACT) exitwith {};
     "CHECKBOX", // setting type
     "AI impacted by Vcom skill settings.", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
     "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
-	true,// data for this setting:
+	  true,// data for this setting:
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
         params ["_value"];
         VCM_SKILLCHANGE = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
+[
+    "VCM_SIDESPECIFICSKILL", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "CHECKBOX", // setting type
+    "Enable Side Specific Skill Parameters", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+	  true,// data for this setting:
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_SIDESPECIFICSKILL = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
 ] call CBA_Settings_fnc_init;
 

--- a/Vcom/Functions/VCM_CBASettings.sqf
+++ b/Vcom/Functions/VCM_CBASettings.sqf
@@ -120,18 +120,6 @@ if !(CBAACT) exitwith {};
     } // function that will be executed once on mission start and every time the setting is changed.
 ] call CBA_Settings_fnc_init;
 
-[
-    "VCM_SKILLCHANGE", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
-    "CHECKBOX", // setting type
-    "AI impacted by Vcom skill settings.", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
-	true,// data for this setting:
-    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-    {
-        params ["_value"];
-        VCM_SKILLCHANGE = _value;
-    } // function that will be executed once on mission start and every time the setting is changed.
-] call CBA_Settings_fnc_init;
 
 [
     "VCM_AIDISTANCEVEHPATH", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
@@ -439,12 +427,25 @@ if !(CBAACT) exitwith {};
 ] call CBA_Settings_fnc_init;
 
 //AI SKILL SETTINGS
+[
+    "VCM_SKILLCHANGE", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "CHECKBOX", // setting type
+    "AI impacted by Vcom skill settings.", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+	true,// data for this setting:
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+        VCM_SKILLCHANGE = _value;
+    } // function that will be executed once on mission start and every time the setting is changed.
+] call CBA_Settings_fnc_init;
+
 //Aiming Accuracy
 [
     "VCM_AISKILL_AIMINGACCURACY_W", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
     "AI Aiming Accuracy (West)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.25,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -457,7 +458,7 @@ if !(CBAACT) exitwith {};
     "VCM_AISKILL_AIMINGACCURACY_E", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
     "AI Aiming Accuracy (East)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.25,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -469,8 +470,8 @@ if !(CBAACT) exitwith {};
 [
     "VCM_AISKILL_AIMINGACCURACY_R", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
-    "AI Aiming Accuracy (Independent)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "AI Aiming Accuracy (Ind)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.25,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -484,7 +485,7 @@ if !(CBAACT) exitwith {};
     "VCM_AISKILL_AIMINGSHAKE_W", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
     "AI Aiming Shake (West)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.15,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -497,7 +498,7 @@ if !(CBAACT) exitwith {};
     "VCM_AISKILL_AIMINGSHAKE_E", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
     "AI Aiming Shake (East)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.15,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -509,8 +510,8 @@ if !(CBAACT) exitwith {};
 [
     "VCM_AISKILL_AIMINGSHAKE_R", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
-    "AI Aiming Shake (Independent)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "AI Aiming Shake (Ind)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.15,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -524,7 +525,7 @@ if !(CBAACT) exitwith {};
     "VCM_AISKILL_AIMINGSPEED_W", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
     "AI Aiming Speed (West)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.35,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -537,7 +538,7 @@ if !(CBAACT) exitwith {};
     "VCM_AISKILL_AIMINGSPEED_E", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
     "AI Aiming Speed (East)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.35,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -549,8 +550,8 @@ if !(CBAACT) exitwith {};
 [
     "VCM_AISKILL_AIMINGSPEED_R", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
-    "AI Aiming Speed (Independent)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    "VCOM SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "AI Aiming Speed (Ind)", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "VCOM SKILL SETTINGS", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     [0,1,0.35,2], // data for this setting: [min, max, default, number of shown trailing decimals]
     true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
     {
@@ -558,6 +559,8 @@ if !(CBAACT) exitwith {};
         VCM_AISKILL_AIMINGSPEED_R = _value;
     } // function that will be executed once on mission start and every time the setting is changed.
 ] call CBA_Settings_fnc_init;
+
+
 
 diag_log "VCOM: Loaded CBA settings";
 

--- a/Vcom/Functions/VcomAI_DefaultSettings.sqf
+++ b/Vcom/Functions/VcomAI_DefaultSettings.sqf
@@ -51,7 +51,7 @@ Vcm_Settings =
 	//VCM_AIDIFA = [['aimingAccuracy',0.15],['aimingShake',0.1],['aimingSpeed',0.25],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
 
 	//MEDIUM DIFFICULTY
-	//VCM_AIDIFA = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+	VCM_AIDIFA = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
 
 	//HIGH DIFFICULTY
 	//VCM_AIDIFA = [['aimingAccuracy',0.35],['aimingShake',0.4],['aimingSpeed',0.45],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];

--- a/Vcom/Functions/VcomAI_DefaultSettings.sqf
+++ b/Vcom/Functions/VcomAI_DefaultSettings.sqf
@@ -72,14 +72,13 @@ Vcm_Settings =
 	VCM_AISKILL_AIMINGSPEED_E = 0.35;
 	VCM_AISKILL_AIMINGSPEED_R = 0.35;
 
-
-	//SIDE SPECIFIC
-	VCM_AIDIFWEST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_W],['aimingShake',VCM_AISKILL_AIMINGSHAKE_W],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_W],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	VCM_AIDIFEAST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_E],['aimingShake',VCM_AISKILL_AIMINGSHAKE_E],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_E],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	VCM_AIDIFRESISTANCE = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_R],['aimingShake',VCM_AISKILL_AIMINGSHAKE_R],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_R],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-
 	VCM_AISIDESPEC =
 	{
+		//Reallocates skill variables before group skill settings are applied
+		VCM_AIDIFWEST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_W],['aimingShake',VCM_AISKILL_AIMINGSHAKE_W],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_W],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+		VCM_AIDIFEAST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_E],['aimingShake',VCM_AISKILL_AIMINGSHAKE_E],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_E],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+		VCM_AIDIFRESISTANCE = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_R],['aimingShake',VCM_AISKILL_AIMINGSHAKE_R],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_R],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+		
 		private _Side = (side (group _this));
 		switch (_Side) do {
 			case west:
@@ -105,7 +104,7 @@ Vcm_Settings =
 
 
 	VCM_CLASSNAMESPECIFIC = false; //Do you want the AI to have classname specific skill settings?
-	VCM_SIDESPECIFICSKILL = false; //Do you want the AI to have side specific skill settings? This overrides classname specific skills.
+	VCM_SIDESPECIFICSKILL = true; //Do you want the AI to have side specific skill settings? This overrides classname specific skills.
 	VCM_SKILL_CLASSNAMES = []; //Here you can assign certain unit classnames to specific skill levels. This will override the AI skill level above.
 
 	/*

--- a/Vcom/Functions/VcomAI_DefaultSettings.sqf
+++ b/Vcom/Functions/VcomAI_DefaultSettings.sqf
@@ -1,4 +1,4 @@
-Vcm_Settings = 
+Vcm_Settings =
 {
 	/*
 		ADDITIONAL COMMANDS
@@ -6,10 +6,10 @@ Vcm_Settings =
 		(group this) setVariable ["VCM_NORESCUE",true]; //This command will stop the AI squad from responding to calls for backup.
 		(group this) setVariable ["VCM_TOUGHSQUAD",true]; //This command will stop the AI squad from calling for backup.
 		(group this) setVariable ["Vcm_Disable",true]; //This command will disable Vcom AI on a group entirely.
-		(group this) setVariable ["VCM_DisableForm",true]; //This command will disable AI group from changing formations.	
-		(group this) setVariable ["VCM_Skilldisable",true]; //This command will disable an AI group from being impacted by Vcom AI skill changes.	
-		
-	*/	
+		(group this) setVariable ["VCM_DisableForm",true]; //This command will disable AI group from changing formations.
+		(group this) setVariable ["VCM_Skilldisable",true]; //This command will disable an AI group from being impacted by Vcom AI skill changes.
+
+	*/
 
 	Vcm_ActivateAI = true; //Set this to false to disable VcomAI. It can be set to true at any time to re-enable Vcom AI
 	VcmAI_ActiveList = []; //Leave this alone.
@@ -18,7 +18,7 @@ Vcm_Settings =
 	VCM_AIMagLimit = 5; //Number of mags remaining before AI looks for ammo.
 	VCM_Debug = false; //Enable debug mode.
 	VCM_MINECHANCE = 75; //Chance to lay a mine
-	
+
 	//VCOM ARTILLERY. Only one kind of advanced artillery can be used at a time.
 	VCM_ARTYENABLE = false; //Enable improved artillery handling from Vcom.
 	VCM_ARTYSIDES = [west,east,resistance];  //Sides that will use VCOM/FFE artillery
@@ -27,79 +27,96 @@ Vcm_Settings =
 	VCM_ARTYWT = -(VCM_ARTYDELAY);
 	VCM_ARTYET = -(VCM_ARTYDELAY);
 	VCM_ARTYRT = -(VCM_ARTYDELAY);
-	VCM_ARTYSPREAD = 400; //Spread of artillery rounds;		
-	
+	VCM_ARTYSPREAD = 400; //Spread of artillery rounds;
+
 	//Fire For Effect Artillery handling. Only one kind of advanced artillery can be used at a time. - https://forums.bohemia.net/forums/topic/159152-fire-for-effect-the-god-of-war-smart-simple-ai-artillery/
 	VCM_FFEARTILLERY = true;
-	
+
 	VCM_SIDEENABLED = [west,east,resistance]; //Sides that will activate Vcom AI
 	VCM_RAGDOLL = true; //Should AI ragdoll when hit
-	VCM_RAGDOLLCHC = 50; //CHANCE AI RAGDOLL	
+	VCM_RAGDOLLCHC = 50; //CHANCE AI RAGDOLL
 	VCM_FullSpeed = true; //Enforce full speedmode during combat (Does not reset after combat end)
 	VCM_HEARINGDISTANCE = 800; //Distance AI hear unsuppressed gunshots.
 	VCM_WARNDIST = 1000; //How far AI can request help from other groups.
 	VCM_WARNDELAY = 30; //How long the AI have to survive before they can call in for support. This activates once the AI enter combat.
-	VCM_STATICARMT = 300; //How long AI stay on static weapons when initially arming them. This is just for AI WITHOUT static bags. They will stay for this duration when NO ENEMIES ARE SEEN, or their group gets FAR away.	
+	VCM_STATICARMT = 300; //How long AI stay on static weapons when initially arming them. This is just for AI WITHOUT static bags. They will stay for this duration when NO ENEMIES ARE SEEN, or their group gets FAR away.
 	VCM_StealVeh = true; //Will the AI steal vehicles.
 	VCM_AIDISTANCEVEHPATH = 100; //Distance AI check from the squad leader to steal vehicles
 	VCM_ADVANCEDMOVEMENT = true; //True means AI will actively generate waypoints if no other waypoints are generated for the AI group (2 or more). False disables this advanced movements.
 	VCM_FRMCHANGE = true; //AI GROUPS WILL CHANGE FORMATIONS TO THEIR BEST GUESS.
 	VCM_SKILLCHANGE = true; //AI Groups will have their skills changed by Vcom.
-	
+
 	//AI SKILL SETTINGS HERE!!!!!!!!!!!!
 	//LOW DIFFICULTY
-	//VCM_AIDIFA = [['aimingAccuracy',0.15],['aimingShake',0.1],['aimingSpeed',0.25],['commanding',1],['courage',1],['endurance',1],['general',0.5],['reloadSpeed',1],['spotDistance',0.8],['spotTime',0.8]];
-		
+	//VCM_AIDIFA = [['aimingAccuracy',0.15],['aimingShake',0.1],['aimingSpeed',0.25],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+
 	//MEDIUM DIFFICULTY
-	VCM_AIDIFA = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	
+	//VCM_AIDIFA = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+
 	//HIGH DIFFICULTY
-	//VCM_AIDIFA = [['aimingAccuracy',0.35],['aimingShake',0.4],['aimingSpeed',0.45],['commanding',1],['courage',1],['endurance',1],['general',0.5],['reloadSpeed',1],['spotDistance',0.8],['spotTime',0.8]];
-	
+	//VCM_AIDIFA = [['aimingAccuracy',0.35],['aimingShake',0.4],['aimingSpeed',0.45],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+
+	//VCOM AI Skill Variables. Default values set to medium difficulty (old default)
+	//AIMING ACCURACY
+	VCM_AISKILL_AIMINGACCURACY_W = 0.25;
+	VCM_AISKILL_AIMINGACCURACY_E = 0.25;
+	VCM_AISKILL_AIMINGACCURACY_R = 0.25;
+
+	//AIMING SHAKE
+	VCM_AISKILL_AIMINGSHAKE_W = 0.15;
+	VCM_AISKILL_AIMINGSHAKE_E = 0.15;
+	VCM_AISKILL_AIMINGSHAKE_R = 0.15;
+
+	//AIMING SPEED
+	VCM_AISKILL_AIMINGSPEED_W = 0.35;
+	VCM_AISKILL_AIMINGSPEED_E = 0.35;
+	VCM_AISKILL_AIMINGSPEED_R = 0.35;
+
+
 	//SIDE SPECIFIC
-	VCM_AIDIFWEST = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	VCM_AIDIFEAST = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	VCM_AIDIFRESISTANCE = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-		
+	VCM_AIDIFWEST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_W],['aimingShake',VCM_AISKILL_AIMINGSHAKE_W],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_W],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+	VCM_AIDIFEAST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_E],['aimingShake',VCM_AISKILL_AIMINGSHAKE_E],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_E],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+	VCM_AIDIFRESISTANCE = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_R],['aimingShake',VCM_AISKILL_AIMINGSHAKE_R],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_R],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+
 	VCM_AISIDESPEC =
 	{
 		private _Side = (side (group _this));
 		switch (_Side) do {
-			case west: 
+			case west:
 			{
 				{
 					_this setSkill _x;
-				} forEach VCM_AIDIFWEST;				
+				} forEach VCM_AIDIFWEST;
 			};
-			case east: 
+			case east:
 			{
 				{
 					_this setSkill _x;
-				} forEach VCM_AIDIFEAST;					
-			}; 
-			case resistance: 
+				} forEach VCM_AIDIFEAST;
+			};
+			case resistance:
 			{
 				{
 					_this setSkill _x;
-				} forEach VCM_AIDIFRESISTANCE;					
-			}; 
-		};		
+				} forEach VCM_AIDIFRESISTANCE;
+			};
+		};
 	};
-	
-	
+
+
 	VCM_CLASSNAMESPECIFIC = false; //Do you want the AI to have classname specific skill settings?
 	VCM_SIDESPECIFICSKILL = false; //Do you want the AI to have side specific skill settings? This overrides classname specific skills.
 	VCM_SKILL_CLASSNAMES = []; //Here you can assign certain unit classnames to specific skill levels. This will override the AI skill level above.
-	
+
 	/*
 	EXAMPLE FOR VCM_SKILL_CLASSNAMES
-	
+
 	VCM_SKILL_CLASSNAMES = [["Classname1",[aimingaccuracy,aimingshake,spotdistance,spottime,courage,commanding,aimingspeed,general,endurance,reloadspeed]],["Classname2",[aimingaccuracy,aimingshake,spotdistance,spottime,courage,commanding,aimingspeed,general,endurance,reloadspeed]]];
 	VCM_SKILL_CLASSNAMES = 	[
 														["B_GEN_Soldier_F",[0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1]],
 														["B_G_Soldier_AR_F",[0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1]]
-													]; 
-	
+													];
+
 	*/
 
 	//Set AI Skill levels
@@ -110,12 +127,12 @@ Vcm_Settings =
 		{
 			private _unit = _x;
 			_unit setSkill 0.9;
-			_unit allowFleeing 0;			
+			_unit allowFleeing 0;
 			{
 				_unit setSkill _x;
 			} forEach VCM_AIDIFA;
-			
-			
+
+
 			if (VCM_CLASSNAMESPECIFIC && {count VCM_SKILL_CLASSNAMES > 0}) then
 			{
 				{
@@ -125,15 +142,15 @@ Vcm_Settings =
 						_unit setSkill ["aimingAccuracy",((_x select 1) select 0)];_unit setSkill ["aimingShake",((_x select 1) select 1)];_unit setSkill ["spotDistance",((_x select 1) select 2)];_unit setSkill ["spotTime",((_x select 1) select 3)];_unit setSkill ["courage",((_x select 1) select 4)];_unit setSkill ["commanding",((_x select 1) select 5)];	_unit setSkill ["aimingSpeed",((_x select 1) select 6)];_unit setSkill ["general",((_x select 1) select 7)];_unit setSkill ["endurance",((_x select 1) select 8)];_unit setSkill ["reloadSpeed",((_x select 1) select 9)];
 					};
 				} foreach VCM_SKILL_CLASSNAMES;
-			};			
-			
+			};
+
 			if (VCM_SIDESPECIFICSKILL) then
 			{
 				_unit call VCM_AISIDESPEC;
 			};
-			
+
 		} forEach (units _this);
-	};	
-	
+	};
+
 	diag_log "VCOM: Loaded Default Settings";
 };

--- a/userconfig/VCOM_AI/AISettingsV3.hpp
+++ b/userconfig/VCOM_AI/AISettingsV3.hpp
@@ -1,4 +1,4 @@
-Vcm_Settings = 
+Vcm_Settings =
 {
 	/*
 		ADDITIONAL COMMANDS
@@ -6,15 +6,15 @@ Vcm_Settings =
 		(group this) setVariable ["VCM_NORESCUE",true]; //This command will stop the AI squad from responding to calls for backup.
 		(group this) setVariable ["VCM_TOUGHSQUAD",true]; //This command will stop the AI squad from calling for backup.
 		(group this) setVariable ["Vcm_Disable",true]; //This command will disable Vcom AI on a group entirely.
-		(group this) setVariable ["VCM_DisableForm",true]; //This command will disable AI group from changing formations.	
-		(group this) setVariable ["VCM_Skilldisable",true]; //This command will disable an AI group from being impacted by Vcom AI skill changes.	
-		
-	*/	
+		(group this) setVariable ["VCM_DisableForm",true]; //This command will disable AI group from changing formations.
+		(group this) setVariable ["VCM_Skilldisable",true]; //This command will disable an AI group from being impacted by Vcom AI skill changes.
+
+	*/
 
 	Vcm_ActivateAI = true; //Set this to false to disable VcomAI. It can be set to true at any time to re-enable Vcom AI
 	VcmAI_ActiveList = []; //Leave this alone.
 	Vcm_ArtilleryArray = []; //Leave this alone
-	
+
 	//VCOM ARTILLERY. Only one kind of advanced artillery can be used at a time.
 	VCM_ARTYENABLE = false; //Enable improved artillery handling from Vcom.
 	VCM_ARTYLST = []; //List of all AI inside of artillery pieces, leave this alone.
@@ -23,7 +23,7 @@ Vcm_Settings =
 	VCM_ARTYET = -(VCM_ARTYDELAY);
 	VCM_ARTYRT = -(VCM_ARTYDELAY);
 	VCM_ARTYSIDES = [west,east,resistance];  //Sides that will use VCOM/FFE artillery
-	VCM_ARTYSPREAD = 400; //Spread of artillery rounds;		
+	VCM_ARTYSPREAD = 400; //Spread of artillery rounds;
 	//Fire For Effect Artillery handling. Only one kind of advanced atrillery can be used at a time. - https://forums.bohemia.net/forums/topic/159152-fire-for-effect-the-god-of-war-smart-simple-ai-artillery/
 	VCM_FFEARTILLERY = true;
 
@@ -32,86 +32,103 @@ Vcm_Settings =
 	VCM_MINECHANCE = 75; //Chance to lay a mine
 	VCM_SIDEENABLED = [west,east,resistance]; //Sides that will activate Vcom AI
 	VCM_RAGDOLL = true; //Should AI ragdoll when hit
-	VCM_RAGDOLLCHC = 50; //CHANCE AI RAGDOLL	
+	VCM_RAGDOLLCHC = 50; //CHANCE AI RAGDOLL
 	VCM_FullSpeed = true; //Enforce full speedmode during combat (Does not reset after combat end)
 	VCM_HEARINGDISTANCE = 800; //Distance AI hear unsuppressed gunshots.
 	VCM_WARNDIST = 1000; //How far AI can request help from other groups.
 	VCM_WARNDELAY = 30; //How long the AI have to survive before they can call in for support. This activates once the AI enter combat.
-	VCM_STATICARMT = 300; //How long AI stay on static weapons when initially arming them. This is just for AI WITHOUT static bags. They will stay for this duration when NO ENEMIES ARE SEEN, or their group gets FAR away.	
+	VCM_STATICARMT = 300; //How long AI stay on static weapons when initially arming them. This is just for AI WITHOUT static bags. They will stay for this duration when NO ENEMIES ARE SEEN, or their group gets FAR away.
 	VCM_StealVeh = true; //Will the AI steal vehicles.
 	VCM_AIDISTANCEVEHPATH = 100; //Distance AI check from the squad leader to steal vehicles
 	VCM_ADVANCEDMOVEMENT = true; //True means AI will actively generate waypoints if no other waypoints are generated for the AI group (2 or more). False disables this advanced movements.
 	VCM_FRMCHANGE = true; //AI GROUPS WILL CHANGE FORMATIONS TO THEIR BEST GUESS.
 	VCM_SKILLCHANGE = true; //AI Groups will have their skills changed by Vcom.
-		
+
 	//AI SKILL SETTINGS HERE!!!!!!!!!!!!
 	//LOW DIFFICULTY
-	//VCM_AIDIFA = [['aimingAccuracy',0.15],['aimingShake',0.1],['aimingSpeed',0.25],['commanding',1],['courage',1],['endurance',1],['general',0.5],['reloadSpeed',1],['spotDistance',0.8],['spotTime',0.8]];
-		
+	//VCM_AIDIFA = [['aimingAccuracy',0.15],['aimingShake',0.1],['aimingSpeed',0.25],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+
 	//MEDIUM DIFFICULTY
-	VCM_AIDIFA = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	
+	//VCM_AIDIFA = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+
 	//HIGH DIFFICULTY
-	//VCM_AIDIFA = [['aimingAccuracy',0.35],['aimingShake',0.4],['aimingSpeed',0.45],['commanding',1],['courage',1],['endurance',1],['general',0.5],['reloadSpeed',1],['spotDistance',0.8],['spotTime',0.8]];
-	
+	//VCM_AIDIFA = [['aimingAccuracy',0.35],['aimingShake',0.4],['aimingSpeed',0.45],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+
+	//VCOM AI Skill Variables. Default values set to medium difficulty (old default)
+	//AIMING ACCURACY
+	VCM_AISKILL_AIMINGACCURACY_W = 0.25;
+	VCM_AISKILL_AIMINGACCURACY_E = 0.25;
+	VCM_AISKILL_AIMINGACCURACY_R = 0.25;
+
+	//AIMING SHAKE
+	VCM_AISKILL_AIMINGSHAKE_W = 0.15;
+	VCM_AISKILL_AIMINGSHAKE_E = 0.15;
+	VCM_AISKILL_AIMINGSHAKE_R = 0.15;
+
+	//AIMING SPEED
+	VCM_AISKILL_AIMINGSPEED_W = 0.35;
+	VCM_AISKILL_AIMINGSPEED_E = 0.35;
+	VCM_AISKILL_AIMINGSPEED_R = 0.35;
+
+
 	//SIDE SPECIFIC
-	VCM_AIDIFWEST = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	VCM_AIDIFEAST = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	VCM_AIDIFRESISTANCE = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-		
+	VCM_AIDIFWEST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_W],['aimingShake',VCM_AISKILL_AIMINGSHAKE_W],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_W],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+	VCM_AIDIFEAST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_E],['aimingShake',VCM_AISKILL_AIMINGSHAKE_E],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_E],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+	VCM_AIDIFRESISTANCE = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_R],['aimingShake',VCM_AISKILL_AIMINGSHAKE_R],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_R],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+
 	VCM_AISIDESPEC =
 	{
 		private _Side = (side (group _this));
 		switch (_Side) do {
-			case west: 
+			case west:
 			{
 				{
 					_this setSkill _x;
-				} forEach VCM_AIDIFWEST;				
+				} forEach VCM_AIDIFWEST;
 			};
-			case east: 
+			case east:
 			{
 				{
 					_this setSkill _x;
-				} forEach VCM_AIDIFEAST;					
-			}; 
-			case resistance: 
+				} forEach VCM_AIDIFEAST;
+			};
+			case resistance:
 			{
 				{
 					_this setSkill _x;
-				} forEach VCM_AIDIFRESISTANCE;					
-			}; 
-		};		
+				} forEach VCM_AIDIFRESISTANCE;
+			};
+		};
 	};
-	
-	
+
+
 	VCM_CLASSNAMESPECIFIC = false; //Do you want the AI to have classname specific skill settings?
 	VCM_SIDESPECIFICSKILL = false; //Do you want the AI to have side specific skill settings? This overrides classname specific skills.
 	VCM_SKILL_CLASSNAMES = []; //Here you can assign certain unit classnames to specific skill levels. This will override the AI skill level above.
-	
+
 	/*
 	EXAMPLE FOR VCM_SKILL_CLASSNAMES
-	
+
 	VCM_SKILL_CLASSNAMES = [["Classname1",[aimingaccuracy,aimingshake,spotdistance,spottime,courage,commanding,aimingspeed,general,endurance,reloadspeed]],["Classname2",[aimingaccuracy,aimingshake,spotdistance,spottime,courage,commanding,aimingspeed,general,endurance,reloadspeed]]];
 	VCM_SKILL_CLASSNAMES = 	[
 														["B_GEN_Soldier_F",[0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1]],
 														["B_G_Soldier_AR_F",[0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1]]
-													]; 
-	
+													];
+
 	*/
 
-		
+
 	VCM_AIDIFSET =
 	{
 		{
 			private _unit = _x;
 			_unit setSkill 0.9;
-			_unit allowFleeing 0;			
+			_unit allowFleeing 0;
 			{
 				_unit setSkill _x;
 			} forEach VCM_AIDIFA;
-			
-			
+
+
 			if (VCM_CLASSNAMESPECIFIC && {count VCM_SKILL_CLASSNAMES > 0}) then
 			{
 				{
@@ -121,15 +138,15 @@ Vcm_Settings =
 						_unit setSkill ["aimingAccuracy",((_x select 1) select 0)];_unit setSkill ["aimingShake",((_x select 1) select 1)];_unit setSkill ["spotDistance",((_x select 1) select 2)];_unit setSkill ["spotTime",((_x select 1) select 3)];_unit setSkill ["courage",((_x select 1) select 4)];_unit setSkill ["commanding",((_x select 1) select 5)];	_unit setSkill ["aimingSpeed",((_x select 1) select 6)];_unit setSkill ["general",((_x select 1) select 7)];_unit setSkill ["endurance",((_x select 1) select 8)];_unit setSkill ["reloadSpeed",((_x select 1) select 9)];
 					};
 				} foreach VCM_SKILL_CLASSNAMES;
-			};			
-			
+			};
+
 			if (VCM_SIDESPECIFICSKILL) then
 			{
 				_unit call VCM_AISIDESPEC;
 			};
-			
+
 		} forEach (units _this);
 	};
-	
+
 	diag_log "VCOM: Loaded Userconfig";
 };

--- a/userconfig/VCOM_AI/AISettingsV3.hpp
+++ b/userconfig/VCOM_AI/AISettingsV3.hpp
@@ -14,22 +14,24 @@ Vcm_Settings =
 	Vcm_ActivateAI = true; //Set this to false to disable VcomAI. It can be set to true at any time to re-enable Vcom AI
 	VcmAI_ActiveList = []; //Leave this alone.
 	Vcm_ArtilleryArray = []; //Leave this alone
+	VCM_ARTYENABLE = true; //Enable improved artillery handling.
+	VCM_AIMagLimit = 5; //Number of mags remaining before AI looks for ammo.
+	VCM_Debug = false; //Enable debug mode.
+	VCM_MINECHANCE = 75; //Chance to lay a mine
 
 	//VCOM ARTILLERY. Only one kind of advanced artillery can be used at a time.
 	VCM_ARTYENABLE = false; //Enable improved artillery handling from Vcom.
+	VCM_ARTYSIDES = [west,east,resistance];  //Sides that will use VCOM/FFE artillery
 	VCM_ARTYLST = []; //List of all AI inside of artillery pieces, leave this alone.
 	VCM_ARTYDELAY = 300; //Delay between squads requesting artillery
 	VCM_ARTYWT = -(VCM_ARTYDELAY);
 	VCM_ARTYET = -(VCM_ARTYDELAY);
 	VCM_ARTYRT = -(VCM_ARTYDELAY);
-	VCM_ARTYSIDES = [west,east,resistance];  //Sides that will use VCOM/FFE artillery
 	VCM_ARTYSPREAD = 400; //Spread of artillery rounds;
-	//Fire For Effect Artillery handling. Only one kind of advanced atrillery can be used at a time. - https://forums.bohemia.net/forums/topic/159152-fire-for-effect-the-god-of-war-smart-simple-ai-artillery/
+
+	//Fire For Effect Artillery handling. Only one kind of advanced artillery can be used at a time. - https://forums.bohemia.net/forums/topic/159152-fire-for-effect-the-god-of-war-smart-simple-ai-artillery/
 	VCM_FFEARTILLERY = true;
 
-	VCM_AIMagLimit = 5; //Number of mags remaining before AI looks for ammo.
-	VCM_Debug = false; //Enable debug mode.
-	VCM_MINECHANCE = 75; //Chance to lay a mine
 	VCM_SIDEENABLED = [west,east,resistance]; //Sides that will activate Vcom AI
 	VCM_RAGDOLL = true; //Should AI ragdoll when hit
 	VCM_RAGDOLLCHC = 50; //CHANCE AI RAGDOLL
@@ -49,7 +51,7 @@ Vcm_Settings =
 	//VCM_AIDIFA = [['aimingAccuracy',0.15],['aimingShake',0.1],['aimingSpeed',0.25],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
 
 	//MEDIUM DIFFICULTY
-	//VCM_AIDIFA = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+	VCM_AIDIFA = [['aimingAccuracy',0.25],['aimingShake',0.15],['aimingSpeed',0.35],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
 
 	//HIGH DIFFICULTY
 	//VCM_AIDIFA = [['aimingAccuracy',0.35],['aimingShake',0.4],['aimingSpeed',0.45],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
@@ -70,14 +72,13 @@ Vcm_Settings =
 	VCM_AISKILL_AIMINGSPEED_E = 0.35;
 	VCM_AISKILL_AIMINGSPEED_R = 0.35;
 
-
-	//SIDE SPECIFIC
-	VCM_AIDIFWEST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_W],['aimingShake',VCM_AISKILL_AIMINGSHAKE_W],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_W],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	VCM_AIDIFEAST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_E],['aimingShake',VCM_AISKILL_AIMINGSHAKE_E],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_E],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-	VCM_AIDIFRESISTANCE = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_R],['aimingShake',VCM_AISKILL_AIMINGSHAKE_R],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_R],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
-
 	VCM_AISIDESPEC =
 	{
+		//Reallocates skill variables before group skill settings are applied
+		VCM_AIDIFWEST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_W],['aimingShake',VCM_AISKILL_AIMINGSHAKE_W],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_W],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+		VCM_AIDIFEAST = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_E],['aimingShake',VCM_AISKILL_AIMINGSHAKE_E],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_E],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+		VCM_AIDIFRESISTANCE = [['aimingAccuracy',VCM_AISKILL_AIMINGACCURACY_R],['aimingShake',VCM_AISKILL_AIMINGSHAKE_R],['aimingSpeed',VCM_AISKILL_AIMINGSPEED_R],['commanding',1],['courage',1],['endurance',1],['general',1],['reloadSpeed',1],['spotDistance',0.85],['spotTime',0.85]];
+		
 		private _Side = (side (group _this));
 		switch (_Side) do {
 			case west:
@@ -103,7 +104,7 @@ Vcm_Settings =
 
 
 	VCM_CLASSNAMESPECIFIC = false; //Do you want the AI to have classname specific skill settings?
-	VCM_SIDESPECIFICSKILL = false; //Do you want the AI to have side specific skill settings? This overrides classname specific skills.
+	VCM_SIDESPECIFICSKILL = true; //Do you want the AI to have side specific skill settings? This overrides classname specific skills.
 	VCM_SKILL_CLASSNAMES = []; //Here you can assign certain unit classnames to specific skill levels. This will override the AI skill level above.
 
 	/*
@@ -117,9 +118,11 @@ Vcm_Settings =
 
 	*/
 
-
+	//Set AI Skill levels
 	VCM_AIDIFSET =
 	{
+		//Skip if Vcom Skillchange is disabled
+		if (!VCM_SKILLCHANGE) exitWith {};
 		{
 			private _unit = _x;
 			_unit setSkill 0.9;
@@ -148,5 +151,5 @@ Vcm_Settings =
 		} forEach (units _this);
 	};
 
-	diag_log "VCOM: Loaded Userconfig";
+	diag_log "VCOM: Loaded Default Settings";
 };


### PR DESCRIPTION
Two bugfixes:
-CBA set  sidespecific skill options are reevaluated before unit skill assignment, ensuring only current values are used. Allows on the fly adjustment of skill values for any unit spawned after skill change.
-Fixed bug where VCM_AIDIFSET routine would not fire due to incorrect checking of VCM_Skilldisable parameter.

-Added SideSpecificSkill option to CBA VCOM SKILL SETTINGS Tab.
-Changed default value of SideSpecificSkill to true in DefaultSettings.
-Updated AISettingsV3.hpp to a cloned version of DefaultSettings.