### PR TITLE
3.3.3 performance fixes

### DIFF
--- a/Vcom/Functions/VCM_Functions/fn_ClstEmy.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_ClstEmy.sqf
@@ -19,7 +19,7 @@ private _unitSide = (side _this);
 private _a1 = [];
 {
 	private _targetSide = side _x;
-	if ([_unitSide, _targetSide] call BIS_fnc_sideIsEnemy && {!(vehicle _X isKindOf "Air")}) then {_a1 pushback _x;};
+	if ([_unitSide, _targetSide] call VCM_fnc_SideIsEnemy && {!(vehicle _X isKindOf "Air")}) then {_a1 pushback _x;};
 } forEach allUnits;
 
 private _rtrn = [_a1,_this,true,"1"] call VCM_fnc_ClstObj;

--- a/Vcom/Functions/VCM_Functions/fn_ClstKnwnEnmy.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_ClstKnwnEnmy.sqf
@@ -17,7 +17,7 @@ private _unitSide = side _this;
 private _a1 = [];
 {
 
-	if ([_unitSide, (_x # 2)] call BIS_fnc_sideIsEnemy && {!((_x # 1) isKindOf "Air")}) then
+	if ([_unitSide, (_x # 2)] call VCM_fnc_SideIsEnemy && {!((_x # 1) isKindOf "Air")}) then
 	{
 		_a1 pushback [(_x # 5),(_x # 4)];
 	};

--- a/Vcom/Functions/VCM_Functions/fn_ClstKnwnEnmy.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_ClstKnwnEnmy.sqf
@@ -11,23 +11,10 @@
 		nil
 */
 
-private _NearTargets = (leader _this) neartargets 2000; 
+private _leader = leader _this;
 
-private _unitSide = side _this;
-private _a1 = [];
-{
+private _NearTargets = _leader nearEntities ["Man", 1000] select {[side _leader, side _x] call VCM_fnc_SideIsEnemy} apply {[_x distance2D player, _x]};
 
-	if ([_unitSide, (_x # 2)] call VCM_fnc_SideIsEnemy && {!((_x # 1) isKindOf "Air")}) then
-	{
-		_a1 pushback [(_x # 5),(_x # 4)];
-	};
-} foreach _NearTargets;
+_NearTargets sort true;
 
-
-if (count _a1 > 0) then
-{
-	_a1 sort true;
-};
-
-
-_a1
+_NearTargets;

--- a/Vcom/Functions/VCM_Functions/fn_EnemyArray.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_EnemyArray.sqf
@@ -17,7 +17,7 @@ private _targetSide = "";
 private _array1 = [];
 {
 	_targetSide = side _x;
-	if ([_unitSide, _targetSide] call BIS_fnc_sideIsEnemy) then {_array1 pushback _x;};
+	if ([_unitSide, _targetSide] call VCM_fnc_SideIsEnemy) then {_array1 pushback _x;};
 
 } forEach allUnits;
 _array1

--- a/Vcom/Functions/VCM_Functions/fn_FriendlyArray.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_FriendlyArray.sqf
@@ -17,6 +17,6 @@ private _UnitSide = side (group _this);
 private _Array1 = [];
 {
 	private _TargetSide = side _x;
-	if (!([_UnitSide, _TargetSide] call BIS_fnc_sideIsEnemy) && {!(_x in (units (group _this)))} && {alive _x}) then {_Array1 pushback _x;};
+	if (!([_UnitSide, _TargetSide] call VCM_fnc_SideIsEnemy) && {!(_x in (units (group _this)))} && {alive _x}) then {_Array1 pushback _x;};
 } forEach allUnits;
 _Array1

--- a/Vcom/Functions/VCM_Functions/fn_FrmChnge.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_FrmChnge.sqf
@@ -20,7 +20,7 @@ _unit = _this;
 _group = group _unit;
 
 //Vehicular groups in "SAFE" behaviour will move in convoys
-if (!isNull objectParent _unit && {behaviour _unit isEqualTo "SAFE"}) exitWith 
+if (!isNull objectParent _unit && {behaviour _unit == "SAFE"}) exitWith 
 {
 	_group setFormation "FILE";
 	//Set the units variable so they dont try changing formations too frequently.

--- a/Vcom/Functions/VCM_Functions/fn_IRCHECK.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_IRCHECK.sqf
@@ -27,7 +27,7 @@ while {alive player && {Vcm_ActivateAI}} do
 		if !(_lineInter isEqualTo []) then
 		{
 			private _finalPos = (_lineInter select 0 select 0);
-			private _enemies = allUnits select {[_side,(side _x)] call BIS_fnc_sideIsEnemy && (currentVisionMode _x isEqualTo 1)};
+			private _enemies = allUnits select {[_side,(side _x)] call VCM_fnc_SideIsEnemy && (currentVisionMode _x isEqualTo 1)};
 			private _dirPlayer = getdir Player;
 			if !(_enemies isEqualTo []) then
 			{

--- a/Vcom/Functions/VCM_Functions/fn_MineMonitor.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_MineMonitor.sqf
@@ -27,7 +27,7 @@ private _RemoveLst = [];
 		{
 			{
 				_TargetSide = side _x;
-				if ([_Side, _TargetSide] call BIS_fnc_sideIsEnemy) then {_EL pushback _x;};
+				if ([_Side, _TargetSide] call VCM_fnc_SideIsEnemy) then {_EL pushback _x;};
 			} forEach _Nearbylist;
 			
 			if (count _EL > 0) then 

--- a/Vcom/Functions/VCM_Functions/fn_RangeEngage.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_RangeEngage.sqf
@@ -19,7 +19,7 @@ if (count _NearestEnemy > 0) then
 
 	private _ShootArray = [];
 	{
-		if (_x # 0 < 15) then
+		if (_Group knowsAbout (_x # 1) > 1.5) then
 		{
 			_ShootArray pushback (_x # 1);
 		};

--- a/Vcom/Functions/VCM_Functions/fn_SniperEngage.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_SniperEngage.sqf
@@ -20,7 +20,7 @@ if (count _NearestEnemys > 0) then
 
 	private _ShootArray = [];
 	{
-		if (_x # 0 < 15) then
+		if (_Group knowsAbout _x >= 1.5) then
 		{
 			_ShootArray pushback (_x # 1);
 		};

--- a/Vcom/Functions/VCM_Functions/fn_sideIsEnemy.sqf
+++ b/Vcom/Functions/VCM_Functions/fn_sideIsEnemy.sqf
@@ -1,0 +1,17 @@
+/** 
+	A version of BI's sideIsEnemy, without the massive performance overhead.
+**/
+
+params ["_center", "_side"];
+
+private _sides = [east, west, independent, civilian, sideUnknown, sideEnemy, sideFriendly, sideLogic, sideEmpty, sideAmbientLife];
+private _friendshipConst = 0.6;
+
+private _index = _sides find _side;
+
+if (_index isEqualTo 6) exitWith {false};
+if (_index isEqualTo 5) exitWith {true};
+
+if (_index < 0 || _index >= 4) exitWith {false};
+
+_center getFriend _side < _friendshipConst;

--- a/Vcom/cfgFunctions.hpp
+++ b/Vcom/cfgFunctions.hpp
@@ -189,6 +189,8 @@ class VCOM
 		//[] call VCM_fnc_UpdateDrivers;
 		class UpdateDrivers {};
 		
+		//[side1, side2] call VCM_fnc_SideIsEnemy
+		class SideIsEnemy {};
 	};		
 
 };


### PR DESCRIPTION
In 3.3.3, there's a stutter that causes the framerate to drop to about 10fps every 10 seconds or so. 

This is caused by some really expensive calls to 'nearTargets', followed by sorting that list - both of those operations cost many milliseconds.

The changes made here alter how ClstKnwnEnmy works to avoid those issues. There may be minor changes to behaviour as a result, but nothing I've noticed in testing.